### PR TITLE
Change pointer casting of CPPFunction

### DIFF
--- a/src/oph_term.c
+++ b/src/oph_term.c
@@ -1769,7 +1769,7 @@ int main(int argc, char **argv, char **envp) {
 
     //Auto-completion
     if (!exec_statement) {
-    	rl_attempted_completion_function = (CPPFunction *)oph_term_completion;
+    	rl_attempted_completion_function = (rl_completion_func_t *)oph_term_completion;
     }
 
     /* MAIN LOOP */


### PR DESCRIPTION
CPPFunction is deprecated in latest version of ubuntu gcc compiler

This commit changes casting of `CPPFunction` to `rl_completion_func_t`
